### PR TITLE
payroll_policy_group: remove required attribute from field and put it in view

### DIFF
--- a/payroll_policy_group/models/hr_policy_group.py
+++ b/payroll_policy_group/models/hr_policy_group.py
@@ -43,6 +43,5 @@ class HrContract(models.Model):
     policy_group_id = fields.Many2one(
         string="Policy Group",
         comodel_name="hr.policy.group",
-        required=True,
         default=_get_policy_group,
     )

--- a/payroll_policy_group/views/hr_policy_group_view.xml
+++ b/payroll_policy_group/views/hr_policy_group_view.xml
@@ -61,7 +61,7 @@
             <field name="arch" type="xml">
                 <data>
                     <xpath expr="//field[@name='wage']" position="after">
-                        <field name="policy_group_id" />
+                        <field name="policy_group_id" required="1" />
                     </xpath>
                 </data>
             </field>


### PR DESCRIPTION
This is to avoid the following error on module installation:
ERROR odoo odoo.schema: Table 'hr_contract': unable to set NOT NULL on column 'policy_group_id'