### PR TITLE
Separate payroll "period" from the "name"

### DIFF
--- a/payroll_period_per_ou/models/hr_payroll_period_schedule.py
+++ b/payroll_period_per_ou/models/hr_payroll_period_schedule.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2022 Trevi Software (https://trevi.et)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import _, fields, models
+from odoo import fields, models
 
 
 class PayrollPeriodSchedule(models.Model):
@@ -25,15 +25,14 @@ class PayrollPeriodSchedule(models.Model):
                 res.update(
                     {
                         "operating_unit_id": ou_ids.ids[0],
-                        "name": f"{res['name']} {ou_ids[0].name}",
+                        "name": f"{ou_ids[0].name}",
                     }
                 )
             if len(ou_ids) > 1:
                 for ou in ou_ids.filtered(lambda x: x.id != res["operating_unit_id"]):
                     other_data = {
-                        "name": _("{}/{} {} {}").format(
-                            str(yearno), str(mo_num), str(mo_name), ou.name
-                        ),
+                        "name": f"{ou.name}",
+                        "period_name": res["period_name"],
                         "schedule_id": res["schedule_id"],
                         "date_start": res["date_start"],
                         "date_end": res["date_end"],

--- a/payroll_period_processing/wizard/process.py
+++ b/payroll_period_processing/wizard/process.py
@@ -196,6 +196,7 @@ class ProcessingWizard(models.TransientModel):
         # Create the payroll register
         register_values = {
             "name": _("%s Payroll Sheet" % (self.payroll_period_id.name)),
+            "period_name": self.payroll_period_id.period_name,
             "date_start": self.payroll_period_id.date_start,
             "date_end": self.payroll_period_id.date_end,
             "period_id": self.payroll_period_id.id,

--- a/payroll_periods/__manifest__.py
+++ b/payroll_periods/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Payroll Period",
     "summary": "Configurable payroll schedules.",
-    "version": "14.0.1.1.4",
+    "version": "14.0.1.2.4",
     "category": "Payroll",
     "images": ["static/src/img/main_screenshot.png"],
     "author": "TREVI Software, Michael Telahun Makonnen",

--- a/payroll_periods/models/hr_payroll_period.py
+++ b/payroll_periods/models/hr_payroll_period.py
@@ -19,7 +19,8 @@ class HrPayrollPeriod(models.Model):
     _inherit = ["mail.thread", "mail.activity.mixin"]
     _order = "date_start, name desc"
 
-    name = fields.Char(string="Description", size=256, required=True)
+    name = fields.Char(string="Description", required=True)
+    period_name = fields.Char()
     schedule_id = fields.Many2one(
         string="Payroll Period Schedule",
         comodel_name="hr.payroll.period.schedule",

--- a/payroll_periods/models/hr_payroll_period_schedule.py
+++ b/payroll_periods/models/hr_payroll_period_schedule.py
@@ -237,6 +237,9 @@ class HrPayperiodSchedule(models.Model):
                     "name": _("{}/{} {}").format(
                         str(year_number), str(month_number), str(month_name)
                     ),
+                    "period name": _("{}/{} {}").format(
+                        str(year_number), str(month_number), str(month_name)
+                    ),
                     "schedule_id": self.id,
                     "date_start": dtStart,
                     "date_end": dtEnd,
@@ -264,6 +267,9 @@ class HrPayperiodSchedule(models.Model):
 
                 data = {
                     "name": _("{}/{} {}").format(
+                        str(year_number), str(month_number), str(month_name)
+                    ),
+                    "period_name": _("{}/{} {}").format(
                         str(year_number), str(month_number), str(month_name)
                     ),
                     "schedule_id": self.id,

--- a/payroll_periods/views/hr_payroll_period_view.xml
+++ b/payroll_periods/views/hr_payroll_period_view.xml
@@ -35,6 +35,7 @@
             <field name="arch" type="xml">
                 <tree string="Payroll Periods">
                     <field name="name" />
+                    <field name="period_name" />
                     <field name="date_start" />
                     <field name="date_end" />
                     <field name="state" />
@@ -81,6 +82,9 @@
                                     name="company_id"
                                     groups="base.group_multi_company"
                                 />
+                            </group>
+                            <group>
+                                <field name="period_name" />
                             </group>
                         </group>
                         <notebook>

--- a/payroll_register/__manifest__.py
+++ b/payroll_register/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Payroll Register",
-    "version": "14.0.1.0.0",
+    "version": "14.0.1.2.0",
     "category": "Payroll",
     "license": "AGPL-3",
     "author": "TREVI Software, Michael Telahun Makonnen",

--- a/payroll_register/models/hr_payroll_register.py
+++ b/payroll_register/models/hr_payroll_register.py
@@ -45,9 +45,8 @@ class HrPayrollRegister(models.Model):
         name = _("Payroll for the Month of %s %s" % (nMonth, year))
         return name
 
-    name = fields.Char(
-        string="Description", size=256, required=True, default=_get_default_name
-    )
+    name = fields.Char(string="Description", required=True, default=_get_default_name)
+    period_name = fields.Char()
     state = fields.Selection(
         string="Status",
         selection=[("draft", "Draft"), ("close", "Close")],
@@ -101,6 +100,15 @@ class HrPayrollRegister(models.Model):
             for den in reg.denomination_ids:
                 res += den.denomination * den.denomination_qty
             reg.exact_change = res
+
+    def name_get(self):
+        res = []
+        for rec in self:
+            if not rec.period_name or rec.period_name in rec.name:
+                res.append((rec.id, f"{rec.name}"))
+            else:
+                res.append((rec.id, f"{rec.period_name} {rec.name}"))
+        return res
 
     def action_delete_runs(self):
 

--- a/payroll_register/views/hr_payroll_register_view.xml
+++ b/payroll_register/views/hr_payroll_register_view.xml
@@ -28,7 +28,7 @@
             <field name="model">hr.payroll.register</field>
             <field name="arch" type="xml">
                 <tree string="Payroll Registers">
-                    <field name="name" />
+                    <field name="display_name" />
                 </tree>
             </field>
         </record>
@@ -64,6 +64,7 @@
                                 <field name="company_id" />
                             </group>
                             <group>
+                                <field name="period_name" />
                             </group>
                          </group>
                         <group>

--- a/payroll_register_report/report/report_payroll_register.xml
+++ b/payroll_register_report/report/report_payroll_register.xml
@@ -12,18 +12,14 @@
                         <t t-set="payroll_tax_heading" t-value="'Pension Fund 7%'" />
                         <center>
                             <h1>
-                                <span t-field="o.name" />
+                                <span t-field="o.company_id.name" />
                             </h1>
                             <h2>
-                                <span
-                                    t-field="o.with_context(tz=o.period_id.schedule_id.tz).date_start"
-                                    t-options="{'widget': 'date'}"
-                                />
-                                - <span
-                                    t-field="o.with_context(tz=o.period_id.schedule_id.tz).date_end"
-                                    t-options="{'widget': 'date'}"
-                                />
+                                <span t-field="o.name" />
                             </h2>
+                            <h3 t-if="o.period_name not in o.name">
+                                <span t-field="o.period_name" />
+                            </h3>
                         </center>
                         <t t-foreach="o.run_ids" t-as="batch">
                             <t


### PR DESCRIPTION
Introduce a separate "period_name" field for payroll periods and payroll
registers. This is semantic separation comes in handy when we need to
distinguish between the name of an object and the period of the object.
For example, when creating payroll periods/register by contract type.