### PR TITLE
Set our version of OCA/Payroll as a dependency of this repo.

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,0 +1,1 @@
+payroll https://github.com/trevi-software/payroll 14.0-trevi


### PR DESCRIPTION
This is so that we don't have to wait on upstream to merge our fixes. Our production instances will use our branch instead of OCA/Payroll.